### PR TITLE
provide useful error message if nb_cats or nb_content is missing

### DIFF
--- a/lib/huginn_naive_bayes_agent/naive_bayes_agent.rb
+++ b/lib/huginn_naive_bayes_agent/naive_bayes_agent.rb
@@ -59,6 +59,14 @@ module Agents
     def receive(incoming_events)
       incoming_events.each do |event|
         nbayes = load(memory['data'])
+        if !event.payload['nb_cats']
+          error("Missing `nb_cats` field in the event payload. #{event.payload.to_s}")
+          return
+        end
+        if !event.payload['nb_content']
+          error("Missing `nb_content` field in the event payload. #{event.payload.to_s}")
+          return
+        end 
         if event.payload['nb_cats'].length > 0 and not event.payload['nb_cats'].include?("=class")
           cats = event.payload['nb_cats'].split(/\s+/)
           if cats[0] == "=loadYML"

--- a/lib/huginn_naive_bayes_agent/naive_bayes_agent.rb
+++ b/lib/huginn_naive_bayes_agent/naive_bayes_agent.rb
@@ -61,11 +61,11 @@ module Agents
         nbayes = load(memory['data'])
         if !event.payload['nb_cats']
           error("Missing `nb_cats` field in the event payload. #{event.payload.to_s}")
-          return
+		  raise 'Missing `nb_cats` field in the event payload.'
         end
         if !event.payload['nb_content']
           error("Missing `nb_content` field in the event payload. #{event.payload.to_s}")
-          return
+          raise 'Missing `nb_content` field in the event payload.'
         end 
         if event.payload['nb_cats'].length > 0 and not event.payload['nb_cats'].include?("=class")
           cats = event.payload['nb_cats'].split(/\s+/)


### PR DESCRIPTION
I added a couple checks that will emit an error message to the log and raise an exception with a similar message if nb_cats or nb_content isn't part of the event payload (or is nil for whatever reason).